### PR TITLE
Mangle: safer, faster mangling of object names

### DIFF
--- a/R/filehash-RDS.R
+++ b/R/filehash-RDS.R
@@ -62,6 +62,9 @@ initializeRDS <- function(dbName) {
 
 mangleName <- function(oname) {
         gsub("([A-Z])", "@\\1", oname, perl = TRUE)
+        if(any(grep("@",oname,fixed=TRUE))) 
+                stop("RDS format cannot cope with objects with @ characters",
+                        " in their names")
 }
 
 unMangleName <- function(mname) {


### PR DESCRIPTION
1. safer
   names containing @s are obviously going to get clobbered on unmangling
2. ~~faster
   I noticed when profiling writing 100 objects of size ~100kb each in RDS format that 10% of the time was spent in gsub.~~
3. ~~maybe a scan for non-ascii object names in mangle would be a good idea~~
