### PR TITLE
Fix connection leak when requested object file does not exist on disk

### DIFF
--- a/R/filehash-RDS.R
+++ b/R/filehash-RDS.R
@@ -117,20 +117,24 @@ setMethod("dbFetch", signature(db = "filehashRDS", key = "character"),
           function(db, key, ...) {
                   ## Create filename from key
                   ofile <- objectFile(db, key)
-
                   ## Open connection
-                  con <- tryCatch({
-                          gzfile(ofile, "rb")
+                  val <- tryCatch({
+                          con<-gzfile(ofile)
+                          # note it is necessary to split creating and opening
+                          # the connection into two steps so that the connection
+                          # can be closed/destroyed successfully if ofile does 
+                          # not exist (avoiding connection leaks).
+                          open(con,"rb")
+                          ## Read data
+                          unserialize(con)
                   }, condition = function(cond) {
                           cond
+                  }, finally = {
+                          close(con)
                   })
-                  if(inherits(con, "condition")) 
+                  if(inherits(val, "condition")) 
                           stop(gettextf("unable to obtain value for key '%s'",
                                         key))
-                  on.exit(close(con))
-
-                  ## Read data
-                  val <- unserialize(con)
                   val
           })
 


### PR DESCRIPTION
If an RDS format filehash is created on disk and an object that does not exist
is requested then there is a connection leak. If this process is repeated >124
times then R runs out of connections (which is of course bad news).

One safe approach appears to be:
- first create connection
- then open it for reading (potentially resulting in error condition)
- always close it (destroying connection) even when erroring out

The problem can be demonstrated as follows:

```
dbCreate("mydbRDS", "RDS")
db <- dbInit("mydbRDS", "RDS")
dbInsert(db, "a", 1:10)
showConnections(all=T)
dbFetch("a")
showConnections(all=T)
dbFetch(db, "nonexistentkey")
showConnections(all=T)
dbUnlink(db)
```

And the exact origin can be seen in these two snippets

```
# Leaks a connection
showConnections(all=TRUE)
con <- tryCatch({
    gzfile(tempfile(),'rb')
}, condition = function(cond) {
    cond
})
showConnections(all=TRUE)

# No connection leak
showConnections(all=TRUE)
val <- tryCatch({
    con<-gzfile(tempfile())
    open(con,'rb')
    readLines(con)
}, condition = function(cond) {
    cond
}, finally = {
    close(con)
})
showConnections(all=TRUE)
```
