### PR TITLE
Suggested fix for race conditiion with lock files

### DIFF
--- a/R/filehash-DB1.R
+++ b/R/filehash-DB1.R
@@ -183,15 +183,17 @@ setMethod("lockFile", "file", function(db, ...) {
 })
 
 createLockFile <- function(name) {
+        # TODO: are these optimal values for max.attempts and sleep.duration?
         max.attempts <- 4
-        attempts = 0
-        status = -1
+        sleep.duration <- 0.5
+        attempts <- 0
+        status <- -1
         while ( (attempts <= max.attempts) && ! isTRUE(status >= 0)) {
           attempts <- attempts + 1
           status <- .Call("lock_file", name)
 
          if(!isTRUE(status >= 0)) {
-           Sys.sleep(0.5)
+           Sys.sleep(sleep.duration)
          }
         }
         if (! isTRUE(status >= 0))


### PR DESCRIPTION
Windows 7 64-bit seems to have a race condition where the lockfile is sometimes present when lock_file is called, but if I wait and call lock_file a few hundred milliseconds later, the lockfile has vanished. (See issue https://github.com/rdpeng/filehash/issues/5).

This patch attempts to fix the problem, and it seems to work reliably on my system. I don't know with certainty whether this might have unintended consequences with other parts of filehash, but I can't see how it would, other than delaying for up to two seconds a failure (stop) from occurring in createLockFile().
