### PR TITLE
Add date field back in

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,5 @@
 Package: filehash
+Date: 2015-08-12
 Version: 2.3
 Depends: R (>= 3.0.0), methods
 Collate: filehash.R filehash-DB1.R filehash-RDS.R coerce.R dump.R


### PR DESCRIPTION
It looks like this commit is not part of the master branch yet, only part of the v2.3 tag. This pull request fixes it.

Thanks for submitting to CRAN. The CRAN version still seems to be 2.2-2, though.

CC @yihui.